### PR TITLE
Revert "Dump lexical, switch to atoi and std"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.3.0]
 
--
+### Changed
+
+- Switched back from `atoi` and `std` to `lexcial` because it has fixed its soundness issues.
 
 ## [0.3.0-beta.0] - 2024-08-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,16 @@ rust-version = "1.56"
 
 [dependencies]
 _serde = { package = "serde", version = "1.0.126", optional = true }
-atoi = "2.0.0"
-num-traits = { version = "0.2.19", default-features = false }
+lexical = { version = "^7.0", optional = true, features = [
+    "std",
+    "parse-integers",
+    "parse-floats",
+], default-features = false }
 
-[dev-dependencies]
+[dev_dependencies]
 _serde = { package = "serde", version = "1.0.126", features = ["derive"] }
 serde_bytes = { version = "0.11" }
 
 [features]
 default = ["serde"]
-serde = ["_serde"]
+serde = ["_serde", "lexical"]

--- a/src/parsers/brackets.rs
+++ b/src/parsers/brackets.rs
@@ -328,7 +328,6 @@ impl<'a> BracketsQS<'a> {
 #[cfg(feature = "serde")]
 mod de {
     use _serde::{de, forward_to_deserialize_any, Deserialize, Deserializer};
-    use atoi::FromRadix10Checked;
 
     use crate::de::{
         Error, ErrorKind, QSDeserializer,
@@ -369,16 +368,11 @@ mod de {
                 .into_iter()
                 .map(|pair| {
                     let index = match pair.0.subkey() {
-                        Some(subkey) if !subkey.is_empty() => {
-                            let (value, len) = usize::from_radix_10_checked(&subkey.0);
-                            value
-                                .and_then(|v| if len == subkey.0.len() { Some(v) } else { None })
-                                .ok_or_else(|| {
-                                    Error::new(ErrorKind::InvalidNumber).message(format!(
-                                        "invalid index: the key has non-numeric characters"
-                                    ))
-                                })?
-                        }
+                        Some(subkey) if !subkey.is_empty() => lexical::parse::<usize, _>(subkey.0)
+                            .map_err(|e| {
+                                Error::new(ErrorKind::InvalidNumber)
+                                    .message(format!("invalid index: {}", e))
+                            })?,
                         _ => 0,
                     };
                     Ok((index, RawSlice(pair.1.unwrap_or_default().slice())))


### PR DESCRIPTION
This reverts commit f7fe8b09166a0493aa002741ef27aa0924667d27.

The `lexical` crate has released a new major version [1] in the meantime, which has fixed the soundness issues [2, 3].

[1] https://github.com/Alexhuszagh/rust-lexical/blob/5af823ff8643527057746153841777449b03d3ca/CHANGELOG#L82-L115

[2] https://rustsec.org/advisories/RUSTSEC-2023-0086

[3] https://rustsec.org/advisories/RUSTSEC-2023-0055